### PR TITLE
Add factory for creating Kvin instances based on RDF configurations

### DIFF
--- a/bundles/io.github.linkedfactory.service/plugin.xml
+++ b/bundles/io.github.linkedfactory.service/plugin.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+	<extension point="net.enilink.komma.model.modules">
+		<module class="io.github.linkedfactory.service.config.ConfigModule"
+				uri="plugin://io.github.linkedfactory.service/">
+		</module>
+	</extension>
+</plugin>

--- a/bundles/io.github.linkedfactory.service/src/main/java/io/github/linkedfactory/service/config/ConfigModule.java
+++ b/bundles/io.github.linkedfactory.service/src/main/java/io/github/linkedfactory/service/config/ConfigModule.java
@@ -1,0 +1,11 @@
+package io.github.linkedfactory.service.config;
+
+import net.enilink.komma.core.KommaModule;
+
+public class ConfigModule extends KommaModule {
+	{
+		// specify dummy type to make KOMMA happy
+		addConcept(IKvinFactory.class, "plugin://io.github.linkedfactory.service/data/Kvin");
+		addBehaviour(KvinLevelDbFactory.class);
+	}
+}

--- a/bundles/io.github.linkedfactory.service/src/main/java/io/github/linkedfactory/service/config/IKvinFactory.java
+++ b/bundles/io.github.linkedfactory.service/src/main/java/io/github/linkedfactory/service/config/IKvinFactory.java
@@ -1,0 +1,14 @@
+package io.github.linkedfactory.service.config;
+
+import io.github.linkedfactory.core.kvin.Kvin;
+
+/**
+ * Factory for creating {@link Kvin} instances.
+ */
+public interface IKvinFactory {
+	/**
+	 * Creates a {@link Kvin} instance
+	 * @return an instance of a {@link Kvin} store
+	 */
+	Kvin create();
+}

--- a/bundles/io.github.linkedfactory.service/src/main/java/io/github/linkedfactory/service/config/KvinLevelDbFactory.java
+++ b/bundles/io.github.linkedfactory.service/src/main/java/io/github/linkedfactory/service/config/KvinLevelDbFactory.java
@@ -1,0 +1,41 @@
+package io.github.linkedfactory.service.config;
+
+import io.github.linkedfactory.core.kvin.Kvin;
+import io.github.linkedfactory.core.kvin.leveldb.KvinLevelDb;
+import net.enilink.composition.annotations.Iri;
+import org.eclipse.core.runtime.Platform;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.net.URISyntaxException;
+
+@Iri("plugin://io.github.linkedfactory.service/data/KvinLevelDb")
+public abstract class KvinLevelDbFactory implements IKvinFactory {
+	private static final Logger log = LoggerFactory.getLogger(KvinLevelDbFactory.class);
+
+	public static String TYPE = "plugin://io.github.linkedfactory.service/data/KvinLevelDb";
+
+	@Override
+	public Kvin create() {
+		String dirName = getDirName();
+		if (dirName == null) {
+			dirName = "linkedfactory-valuestore";
+		}
+		File valueStorePath;
+		if (new File(dirName).isAbsolute()) {
+			valueStorePath = new File(dirName);
+		} else {
+			try {
+				valueStorePath = new File(new File(Platform.getInstanceLocation().getURL().toURI()), dirName);
+			} catch (URISyntaxException e) {
+				throw new RuntimeException(e);
+			}
+		}
+		log.info("Using store path: {}", valueStorePath);
+		return new KvinLevelDb(valueStorePath);
+	}
+
+	@Iri("plugin://io.github.linkedfactory.service/data/dirName")
+	public abstract String getDirName();
+}

--- a/bundles/io.github.linkedfactory.service/src/main/resources/OSGI-INF/io.github.linkedfactory.service-default.ttl
+++ b/bundles/io.github.linkedfactory.service/src/main/resources/OSGI-INF/io.github.linkedfactory.service-default.ttl
@@ -5,5 +5,5 @@
 # <> <mockdata> [ <machines> 10 ] ; <mocktracker> true .
 
 @base <plugin://io.github.linkedfactory.service/data/> .
-<store> <model>   <http://linkedfactory.github.io/data/> ;
-        <dirName> "linkedfactory-valuestore" .
+<> <defaultModel> <http://linkedfactory.github.io/data/> .
+<> <store> [ a <KvinLevelDb> ; <dirName> "linkedfactory-valuestore" ] .


### PR DESCRIPTION
This change adds the ability to configure different Kvin implementations via a factory pattern using RDF types and associated configuration properties.