### PR TITLE
Updated getUnitOfWork from contextModelSet

### DIFF
--- a/bundles/io.github.linkedfactory.service/src/main/scala/io/github/linkedfactory/service/Data.scala
+++ b/bundles/io.github.linkedfactory.service/src/main/scala/io/github/linkedfactory/service/Data.scala
@@ -95,17 +95,17 @@ object Data {
       override def entityCreated(item: URI): Unit = {
         // FIXME: add/use actual subject via session/token/...
         modelForRequest.foreach { m =>
+          val uow = Globals.contextModelSet.vend.map(_.getUnitOfWork)
           createHierarchyExecutor.submit(new Runnable {
             override def run(): Unit = {
               Subject.doAs(SecurityUtil.SYSTEM_USER_SUBJECT, toPEA(() => {
-                val uow = m.getModelSet.getUnitOfWork
-                uow.begin()
+                uow.foreach(_.begin())
                 try {
                   withTransaction(m.getManager) { manager =>
                     createHierarchy(item, manager)
                   }
                 } finally {
-                  uow.end()
+                  uow.foreach(_.end())
                 }
               }))
             }


### PR DESCRIPTION
### Summary
This pull request changes the code responsible for handling the creation of entities within the `KvinListener`. 
This is done by changing how the unit of work is derived from the _contextModelSet_.

**What:** use `Globals.contextModelSet.vend.map(_.getUnitOfWork)` for obtaining the unit of work, replacing the previous method of accessing it directly from `m.getModelSet.getUnitOfWork`.

